### PR TITLE
Potential fix for code scanning alert no. 81: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -18,7 +18,7 @@ class ErrorWithParent extends Error {
 // vuln-code-snippet start unionSqlInjectionChallenge dbSchemaChallenge
 module.exports = function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    let criteria: any = (typeof req.query.q === 'string') ? req.query.q : ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/dsp-testing/saritai-juice-shop/security/code-scanning/81](https://github.com/dsp-testing/saritai-juice-shop/security/code-scanning/81)

To fix the problem, we need to ensure that `req.query.q` is a string before performing any operations on it. This can be done by adding a type check and handling the case where `req.query.q` is not a string. If `req.query.q` is not a string, we can set `criteria` to an empty string or handle it appropriately.

The best way to fix the problem without changing existing functionality is to add a type check for `req.query.q` and ensure it is a string before proceeding with the rest of the code. This involves modifying the code at line 21 to include a type check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
