### PR TITLE
Potential fix for code scanning alert no. 46: Uncontrolled data used in path expression

### DIFF
--- a/routes/keyServer.ts
+++ b/routes/keyServer.ts
@@ -10,8 +10,11 @@ module.exports = function serveKeyFiles () {
   return ({ params }: Request, res: Response, next: NextFunction) => {
     const file = params.file
 
-    if (!file.includes('/')) {
-      res.sendFile(path.resolve('encryptionkeys/', file))
+    const rootDir = path.resolve('encryptionkeys/')
+    const resolvedPath = path.resolve(rootDir, file)
+
+    if (resolvedPath.startsWith(rootDir) && !file.includes('/')) {
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
       next(new Error('File names cannot contain forward slashes!'))


### PR DESCRIPTION
Potential fix for [https://github.com/dsp-testing/saritai-juice-shop/security/code-scanning/46](https://github.com/dsp-testing/saritai-juice-shop/security/code-scanning/46)

To fix the issue, we need to ensure that the file path constructed from user input is safe and confined to the intended directory (`encryptionkeys/`). This can be achieved by normalizing the path using `path.resolve` and then verifying that the resolved path starts with the intended root directory. This approach prevents path traversal attacks by ensuring that the resolved path does not escape the root directory.

Steps to fix:
1. Use `path.resolve` to normalize the file path relative to the `encryptionkeys/` directory.
2. Check that the resolved path starts with the absolute path of the `encryptionkeys/` directory.
3. If the resolved path does not start with the intended directory, return a 403 status code and an error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
